### PR TITLE
Drop ruby 2.0 from Travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,19 +1,7 @@
 language: ruby
-matrix:
-  exclude:
-    - rvm: 2.0.0
-      gemfile: gemfiles/Gemfile.rails-4.0.x
-    - rvm: 2.0.0
-      gemfile: gemfiles/Gemfile.rails-4.1.x
-    - rvm: 2.0.0
-      gemfile: gemfiles/Gemfile.rails-4.2.x
-    - rvm: 2.0.0
-      gemfile: gemfiles/Gemfile.rails-5.0.x
-
-rvm: 
-  - 2.0.0
-  - 2.2.4
-  - 2.3.0
+rvm:
+  - 2.2.5
+  - 2.3.1
 gemfile:
   - Gemfile
   - gemfiles/Gemfile.rails-4.1.x


### PR DESCRIPTION
I intend to drop support for older Ruby and Rails versions. This will adjust the Travis config to exclude the Ruby 2.0.0 tests, so I have a greenfield to test.